### PR TITLE
chore: stronger defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const NO_PASSWORD = 'A password is required for encryption or decryption.'
 const COULD_NOT_DECRYPT = 'Could not decrypt!'
 
 const SALT_LENGTH = 2 ** 12 // 4096 bytes / 32768 bits
-const KEY_LENGTH = 2 ** 5   // 32 bytes / 256 bits
-const ITERATIONS = 1e5      // 1 & 5 zeroes / 100,000
+const KEY_LENGTH = 2 ** 5 // 32 bytes / 256 bits
+const ITERATIONS = 1e5 // 1 & 5 zeroes / 100,000
 
 // istanbul ignore next // for some reason
 function getDefaultOpts (opts = {}) {

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ const { pbkdf2, createSHA512 } = require('hash-wasm')
 const NO_PASSWORD = 'A password is required for encryption or decryption.'
 const COULD_NOT_DECRYPT = 'Could not decrypt!'
 
-const SALT_LENGTH = 32
-const KEY_LENGTH = 32
-const ITERATIONS = 1e4
+const SALT_LENGTH = 2 ** 12 // 4096 bytes / 32768 bits
+const KEY_LENGTH = 2 ** 5   // 32 bytes / 256 bits
+const ITERATIONS = 1e5      // 1 & 5 zeroes / 100,000
 
 // istanbul ignore next // for some reason
 function getDefaultOpts (opts = {}) {

--- a/test.js
+++ b/test.js
@@ -77,4 +77,10 @@ describe('crypt', function () {
     const decrypted = await crypt2.decrypt(encrypted)
     assert.equal(decrypted, PLAINTEXT)
   })
+
+  it('should create an instance asynchronously', async function () {
+    const crypt = await Crypt.new(PASSWORD)
+    assert(crypt._key)
+    assert(crypt._salt)
+  })
 })

--- a/test.js
+++ b/test.js
@@ -8,6 +8,8 @@ const PASSWORD = 'password'
 const BENCHMARK = 1e4 // note: 1e4 = 1 and 4 zeroes (10,000)
 
 describe('crypt', function () {
+  this.timeout(1000 * 10) // 10 seconds
+  
   it('should derive a key from a password', async function () {
     let { key, salt } = await Crypt.deriveKey(PASSWORD)
     key = encodeBase64(key)
@@ -68,7 +70,6 @@ describe('crypt', function () {
   })
 
   it('should import from an export payload', async function () {
-    this.timeout(1000 * 10) // 10 seconds
     const crypt1 = new Crypt(PASSWORD)
     const exportString = await crypt1.export()
     const crypt2 = await Crypt.import(PASSWORD, exportString)

--- a/test.js
+++ b/test.js
@@ -68,6 +68,7 @@ describe('crypt', function () {
   })
 
   it('should import from an export payload', async function () {
+    this.timeout(1000 * 10) // 10 seconds
     const crypt1 = new Crypt(PASSWORD)
     const exportString = await crypt1.export()
     const crypt2 = await Crypt.import(PASSWORD, exportString)

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ const BENCHMARK = 1e4 // note: 1e4 = 1 and 4 zeroes (10,000)
 
 describe('crypt', function () {
   this.timeout(1000 * 10) // 10 seconds
-  
+
   it('should derive a key from a password', async function () {
     let { key, salt } = await Crypt.deriveKey(PASSWORD)
     key = encodeBase64(key)


### PR DESCRIPTION
This PR increases the defaults of crypt's cryptographic settings, including its default salt length (32 bytes => 4096 bytes) and iterations (10k => 100k).

It is hard for me to tell exactly how much stronger this makes crypt's cryptography, but fwiw it would require a 4128-byte rainbow table to defeat. As the default salt is now about 4kb, this makes export strings considerably longer.